### PR TITLE
adding ability to stream output

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -37,7 +37,7 @@ jobs:
         pytest -xs flux_restful_client/tests/test_api.py
 
   test-auth:
-    needs: [build-container]
+    needs: [prepare-container]
     runs-on: ubuntu-latest
     services:
       api:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -6,14 +6,28 @@ on:
     - main
     - gh-pages
 
+
 jobs:
+  prepare-container:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.extract_branch.outputs.branch }}
+    steps:
+    - name: Extract branch name
+      run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+      id: extract_branch
+
   test-noauth:
     runs-on: ubuntu-latest
+    needs: [prepare-container]
     services:
       api:
         image: ghcr.io/flux-framework/flux-restful-api:latest
         ports:
           - 5000:5000
+        env:
+          INSTALL_BRANCH: ${{ needs.prepare-container.outputs.branch }}
+          INSTALL_REPO: ${{ github.repository }}
     steps:
     - uses: actions/checkout@v3
     - name: Run tests without auth
@@ -23,10 +37,13 @@ jobs:
         pytest -xs flux_restful_client/tests/test_api.py
 
   test-auth:
+    needs: [build-container]
     runs-on: ubuntu-latest
     services:
       api:
         env:
+          INSTALL_BRANCH: ${{ needs.prepare-container.outputs.branch }}
+          INSTALL_REPO: ${{ github.repository }}
           FLUX_USER: fluxuser
           FLUX_TOKEN: "12345"
           FLUX_REQUIRE_AUTH: true

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/flux-framework/flux-restful-api/tree/main) (0.0.x)
+ - support for streaming job output (0.0.13)
  - ensure logs end with one newline! (0.0.12)
  - support for job info and logs (0.0.11)
  - Parse envars from the command line, add descriptions for submit (0.0.1)

--- a/clients/python/flux_restful_client/client/__init__.py
+++ b/clients/python/flux_restful_client/client/__init__.py
@@ -178,6 +178,14 @@ flux-restful-cli config inituser""",
         description="get log output for a job",
         formatter_class=argparse.RawTextHelpFormatter,
     )
+
+    logs.add_argument(
+        "--stream",
+        help="stream logs as they are available (does not block).",
+        default=False,
+        action="store_true",
+    )
+
     subparsers.add_parser(
         "list-nodes",
         description="list node that the Flux RESTful API knows about",

--- a/clients/python/flux_restful_client/client/logs.py
+++ b/clients/python/flux_restful_client/client/logs.py
@@ -9,7 +9,7 @@ def main(args, parser, extra, subparser):
     # Update config settings on the fly
     cli.settings.update_params(args.config_params)
     if args.stream:
-        for line in cli.output(jobid=args.jobid, stream=args.stream):
+        for line in cli.stream_output(jobid=args.jobid, stream=args.stream):
             print(line.strip())
     else:
         logs = cli.output(jobid=args.jobid, stream=args.stream)

--- a/clients/python/flux_restful_client/client/logs.py
+++ b/clients/python/flux_restful_client/client/logs.py
@@ -8,10 +8,14 @@ def main(args, parser, extra, subparser):
 
     # Update config settings on the fly
     cli.settings.update_params(args.config_params)
-    logs = cli.output(jobid=args.jobid)
-    if "Output" in logs:
-        for line in logs["Output"]:
-            # Ensure we only have one newline!
+    if args.stream:
+        for line in cli.output(jobid=args.jobid, stream=args.stream):
             print(line.strip())
     else:
-        print(json.dumps(logs, indent=4))
+        logs = cli.output(jobid=args.jobid, stream=args.stream)
+        if "Output" in logs:
+            for line in logs["Output"]:
+                # Ensure we only have one newline!
+                print(line.strip())
+        else:
+            print(json.dumps(logs, indent=4))

--- a/clients/python/flux_restful_client/main/client.py
+++ b/clients/python/flux_restful_client/main/client.py
@@ -148,16 +148,20 @@ class FluxRestfulClient:
         """
         return self.do_request(f"jobs/{jobid}/cancel", "POST").json()
 
-    def output(self, jobid, stream=False):
+    def stream_output(self, jobid):
         """
-        Request for a job to be cancelled based on identifier.
+        Request for job output to be streamed
         """
-        if not stream:
-            return self.do_request(f"jobs/{jobid}/output", "GET").json()
         response = self.do_request(f"jobs/{jobid}/output/stream", "GET", stream=True)
         for line in response.iter_lines():
             if line:
                 yield line.decode("utf-8")
+
+    def output(self, jobid):
+        """
+        Request for a job to be cancelled based on identifier.
+        """
+        return self.do_request(f"jobs/{jobid}/output", "GET").json()
 
     def stop_service(self):
         """

--- a/clients/python/flux_restful_client/version.py
+++ b/clients/python/flux_restful_client/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "flux-restful-client"

--- a/docs/getting_started/developer-guide.md
+++ b/docs/getting_started/developer-guide.md
@@ -59,6 +59,16 @@ $ docker run --name flux-restful -d --rm -it -p 5000:5000 ghcr.io/flux-framework
 $ docker stop flux-restful
 ```
 
+Finally, if you want to install a custom branch (and/or repository) of the RESTFul API, we provide
+an environment variable to do this. E.g., this makes it easy to test a custom branch in CI without
+needing to push a container to a registry. Here is how to specify a branch (and default to flux-framework/flux-restful-api)
+or your own repository base:
+
+```bash
+$ docker run  --env INSTALL_BRANCH=add/feature --env INSTALL_REPO=user/flux-restful-api -d --rm -it -p 5000:5000 ghcr.io/flux-framework/flux-restful-api
+```
+
+
 ### Local
 
 You can use this setup locally (if you have flux and Python available) or within the Dev Container

--- a/docs/getting_started/user-guide.md
+++ b/docs/getting_started/user-guide.md
@@ -212,7 +212,7 @@ $ flux-restful-cli info 12402053611520
 
 ### Logs
 
-To see output for a job, just do:
+To see output for a job, there are two options. You can ask for all logs (blocking, will return when job is done):
 
 ```bash
 $ flux-restful-cli logs 12402053611520
@@ -220,6 +220,12 @@ $ flux-restful-cli logs 12402053611520
 ```console
 # flux-restful-cli logs 244509770252288
 pancakes 🥞🥞🥞🥞🥞
+```
+
+Or you can ask to stream:
+
+```bash
+$ flux-restful-cli logs --stream 12402053611520
 ```
 
 If you get a message that the output doesn't exist, it usually means your job didn't have output (e.g., sleep),

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,12 +4,12 @@ install_branch=${INSTALL_BRANCH}
 install_repo=${INSTALL_REPO:-flux-framework/flux-restful-api}
 
 # If we are given a custom branch to install, do that first
-if [ ! -z ${install_branch+x} ]; then
+if [[ ! -z ${install_branch} ]]; then
+    cd /tmp
     printf "Custom install of https://github.com:${install_repo}@${install_branch}"
     rm -rf /code
-    git clone -b ${install_branch} https://github.com:${install_repo} /code
+    git clone -b ${install_branch} https://github.com/${install_repo} /code
+    cd /code
 fi
 
-# Ensure we are still in /code as PWD
-cd /code
 flux start uvicorn app.main:app --host=${HOST} --port=${PORT}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,15 @@
 #!/bin/bash
 
+install_branch=${INSTALL_BRANCH}
+install_repo=${INSTALL_REPO:-flux-framework/flux-restful-api}
+
+# If we are given a custom branch to install, do that first
+if [ ! -z ${install_branch+x} ]; then
+    printf "Custom install of https://github.com:${install_repo}@${install_branch}"
+    rm -rf /code
+    git clone -b ${install_branch} https://github.com:${install_repo} /code
+fi
+
+# Ensure we are still in /code as PWD
+cd /code
 flux start uvicorn app.main:app --host=${HOST} --port=${PORT}

--- a/templates/include/jobs/result.html
+++ b/templates/include/jobs/result.html
@@ -1,3 +1,7 @@
-{% if job.result == "COMPLETED "%}<button class="btn" style="background-color:darkseagreen">{{ job.result }}</button>{% else %}
-<button class="btn" style="background-color:skyblue">{{ job.result }}</button>
+{% if job.result == "COMPLETED "%}<button class="btn" style="min-width:150px; background-color:darkseagreen">{{ job.result }} 💚</button>{% elif job.result == "FAILED" %}
+<button class="btn" style="min-width:150px; color:white; background-color:darkred">{{ job.result }} 😭</button>{% elif job.result == "CANCELED" %}
+<button class="btn" style="min-width:150px; background-color: goldenrod">{{ job.result }} 🥐</button>{% elif job.result == "TIMEOUT" %}
+<button class="btn" style="min-width:150px; background-color:skyblue">{{ job.result }} 🍕</button>
+{% else %}
+<button class="btn" style="min-width:150px; background-color:gray;color:white">NO RESULT 😞</button>
 {% endif %}

--- a/templates/include/jobs/state.html
+++ b/templates/include/jobs/state.html
@@ -1,6 +1,7 @@
-{% if job.state == "INACTIVE" %}<button class="btn" style="background-color:grey;color:white">{{ job.state }} 😴 </button>{% elif job.state == "RUN" %}
-<button class="btn" style="background-color:grey">{{ job.state }} 🏃 </button>{% elif job.state == "CANCELLED" %}
-<button class="btn" style="background-color:grey">{{ job.state }} 🎉  </button>{% elif job.state == "COMPLETED" %}
-<button class="btn" style="background-color:grey">{{ job.state }} 🚧  </button>{% else %}
-<button class="btn" style="background-color:skyblue">{{ job.state }}</button>
+{% if job.state == "INACTIVE" %}<button class="btn" style="min-width:150px; background-color:grey;color:white">{{ job.state }} 😴 </button>{% elif job.state == "RUN" %}
+<button class="btn" style="min-width:150px; background-color:skyblue">{{ job.state }} 🏃 </button>{% elif job.state == "SCHED" %}
+<button class="btn" style="min-width:150px; background-color:skyblue">{{ job.state }} 📅  </button>{% elif job.state == "DEPEND" %}
+<button class="btn" style="min-width:150px; background-color:skyblue">{{ job.state }} 🚧  </button>{% elif job.state == "CLEANUP" %}
+<button class="btn" style="min-width:150px; background-color:skyblue">{{ job.state }} 🧼 </button>{% else %}
+<button class="btn" style="min-width:150px; background-color:skyblue">PENDING ⌚</button>
 {% endif %}

--- a/templates/include/messages.html
+++ b/templates/include/messages.html
@@ -3,7 +3,7 @@
    <div class="row">
       <div class="col">
         <div class="mb-3">{% for message in messages %}
-            <p class="alert alert-info alert-dismissible">{{ message }}</p>{% endfor %}
+            <p class="alert alert-info alert-dismissible">{{ message | safe }}</p>{% endfor %}
         </div>
       </div>
    </div>

--- a/templates/jobs/jobs.html
+++ b/templates/jobs/jobs.html
@@ -110,15 +110,22 @@ $(document).ready(function() {
             { // result
                 createdCell: function (td, data, rowData, row, col) {
                     color = "skyblue"
+                    fontcolor = "white"
                     if (data == "INACTIVE") {
                         color = "grey"
                     }
-                    if (data == "CANCELLED") {
-                        color = "yellow"
+                    if (data == "CANCELED") {
+                        color = "goldenrod"
+                        fontcolor = "black"
                     }
                     if (data == "COMPLETED") {
                         color = "darkseagreen"
+                        fontcolor = "black"
                     }
+                    if (data == "FAILED") {
+                        color = "darkred"
+                    }
+                    $(td).css('color', fontcolor);
                     $(td).css('background-color', color);
                 },
                 targets: 3


### PR DESCRIPTION
This also fixes a bug in the UI that we could not see output until the job finished. I also realized I had a natural inclination to want to click on the jobid after submit, so I've turned that into a bright pink link. Finally,
we add emojis/colors for the different result/state, and a new streaming logs endpoint (and example with the client)

Other updates:

- the container entrypoint can now take envars that will clone a specific branch and/or repo. This means we can more easily test on the fly.
- the functions to stream (or not) are provided separately in the client so it's more easy to discover

Signed-off-by: vsoch <vsoch@users.noreply.github.com>