### PR TITLE
ensure in /code as workdir

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,8 @@ if [[ ! -z ${install_branch} ]]; then
     printf "Custom install of https://github.com:${install_repo}@${install_branch}"
     rm -rf /code
     git clone -b ${install_branch} https://github.com/${install_repo} /code
-    cd /code
 fi
 
+# We always need to start in this PWD
+cd /code
 flux start uvicorn app.main:app --host=${HOST} --port=${PORT}


### PR DESCRIPTION
it is common to change WORKDIR using this as a base container, and the app requires it (for now) so we changedir there in the entrypoint.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>