### PR TITLE
add cancel button

### DIFF
--- a/app/library/flux.py
+++ b/app/library/flux.py
@@ -110,6 +110,22 @@ def stream_job_output(jobid):
         pass
 
 
+def cancel_job(jobid):
+    """
+    Request a job to be cancelled by id.
+
+    Returns a message to the user and a return code.
+    """
+    from app.main import app
+
+    try:
+        flux.job.cancel(app.handle, jobid)
+    # This is usually FileNotFoundError
+    except Exception as e:
+        return "Job cannot be cancelled: %s." % e, 400
+    return "Job is requested to cancel.", 200
+
+
 def get_job_output(jobid, delay=None):
     """
     Given a jobid, get the output.

--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,9 @@ static_root = os.path.join(root, "static")
 data_root = os.path.join(root, "data")
 template_root = os.path.join(root, "templates")
 
+# Create templates, ensure we can get flashed messages from template session
 templates = Jinja2Templates(directory=template_root)
+
 app.mount("/static", StaticFiles(directory=static_root), name="static")
 app.mount("/data", StaticFiles(directory=data_root), name="data")
 

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -122,19 +122,8 @@ async def cancel_job(jobid):
     """
     Cancel a running flux job
     """
-    from app.main import app
-
-    try:
-        flux.job.cancel(app.handle, jobid)
-    # This is usually FileNotFoundError
-    except Exception as e:
-        return JSONResponse(
-            content={"Message": "Job cannot be cancelled: %s." % e}, status_code=400
-        )
-
-    return JSONResponse(
-        content={"Message": "Job is requested to cancel."}, status_code=200
-    )
+    message, return_code = flux_cli.cancel_job(jobid)
+    return JSONResponse(content={"Message": message}, status_code=return_code)
 
 
 @router.post("/jobs/submit")

--- a/templates/include/messages.html
+++ b/templates/include/messages.html
@@ -4,7 +4,7 @@
       <div class="col">
         <div class="mb-3">{% for message in messages %}
             <p class="alert alert-info alert-dismissible">{{ message | safe }}</p>{% endfor %}
-        </div>
+         </div>
       </div>
    </div>
 </div>{% endif %}

--- a/templates/jobs/job.html
+++ b/templates/jobs/job.html
@@ -69,6 +69,10 @@
                     <td scope="row">Return Code</td>
                     <td>{{ job.returncode }}</td>
                   </tr>
+                  {% if job.state != "INACTIVE" %}<tr>
+                    <td scope="row">Actions</td>
+                    <td><a href="/job/{{ job.id }}/cancel" type="button" class="btn-warning btn">Request Cancel</a></td>
+                  </tr>{% endif %}
                 </tbody>
               </table>
         </div>


### PR DESCRIPTION
A user should be able to request cancel for a job from the ui!

 - Fixes #31 

Given we submit a sleep job, I can now see a cancel button:
![Screenshot 2022-11-20 at 19-22-18 Flux RESTFul Interface FastAPI Flux Interace](https://user-images.githubusercontent.com/814322/202950724-f95e81bb-dc53-47c2-8827-108c692933c9.png)

And then clicking it, cancel actually works pretty quickly. Maybe for more complex jobs it would take longer.
![Screenshot 2022-11-20 at 19-27-51 Flux RESTFul Interface FastAPI Flux Interace](https://user-images.githubusercontent.com/814322/202950739-4473128e-8325-481b-9e84-d90d6af5f788.png)

And the table reflects the update!

![image](https://user-images.githubusercontent.com/814322/202950706-d1cc05dc-a6ee-4c43-831c-27e570b6ae1d.png)

The underlying functionality to cancel (via the API or via this button) is now shared using the `flux_cli.cancel_job`

Signed-off-by: vsoch <vsoch@users.noreply.github.com>