### PR TITLE
adding support for flux option flags

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,6 +1,11 @@
+import logging
 import os
+import re
+import shlex
 
 from pydantic import BaseSettings
+
+logger = logging.getLogger(__name__)
 
 
 def get_int_envar(key, default=None):
@@ -24,6 +29,35 @@ def get_bool_envar(key, default=False):
     return default if not os.environ.get(key) else not default
 
 
+def get_option_flags(key, prefix="-o"):
+    """
+    Wrapper around parse_option_flags to get from environment.
+
+    The function can then be shared to parse flags from the UI
+    in the same way.
+    """
+    flags = os.environ.get(key) or {}
+    if not flags:
+        return flags
+    return parse_option_flags(flags, prefix)
+
+
+def parse_option_flags(flags, prefix="-o"):
+    """
+    Parse key value pairs (optionally with a prefix) from the environment.
+    """
+    values = {}
+    for flag in shlex.split(flags):
+        if "=" not in flag:
+            logger.warning(f"Missing '=' in flag {flag}, cannot parse.")
+            continue
+        option, value = flag.split("=", 1)
+        if option.startswith(prefix):
+            option = re.sub(f"^{prefix}", "", option)
+        values[option] = value
+    return values
+
+
 class Settings(BaseSettings):
     """
     Basic settings and defaults for the Flux RESTFul API
@@ -40,6 +74,9 @@ class Settings(BaseSettings):
     flux_user: str = os.environ.get("FLUX_USER")
     flux_token: str = os.environ.get("FLUX_TOKEN")
     require_auth: bool = get_bool_envar("FLUX_REQUIRE_AUTH")
+
+    # Default server option flags
+    option_flags: dict = get_option_flags("FLUX_OPTION_FLAGS")
 
     # If the user requests a launcher, be strict.
     # We only allow nextflow and snakemake, sorry

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -8,10 +8,10 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 
+import app.core.config as config
 import app.library.flux as flux_cli
 import app.library.helpers as helpers
 import app.library.launcher as launcher
-from app.core.config import settings
 from app.library.auth import alert_auth, check_auth
 
 # Print (hidden message) to give status of auth
@@ -19,7 +19,7 @@ alert_auth()
 router = APIRouter(
     prefix="/v1",
     tags=["jobs"],
-    dependencies=[Depends(check_auth)] if settings.require_auth else [],
+    dependencies=[Depends(check_auth)] if config.settings.require_auth else [],
     responses={404: {"description": "Not found"}},
 )
 no_auth_router = APIRouter(prefix="/v1", tags=["jobs"])
@@ -155,8 +155,9 @@ async def submit_job(request: Request):
     # Optional arguments
     as_int = ["num_tasks", "cores_per_task", "gpus_per_task", "num_nodes"]
     as_bool = ["exclusive"]
+    as_is = ["option_flags"]
 
-    for optional in as_int + as_bool:
+    for optional in as_int + as_bool + as_is:
         if optional in payload and payload[optional]:
             if optional in as_bool:
                 kwargs[optional] = bool(payload[optional])

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/flux-framework/flux-restful-api/tree/main) (0.0.x)
+ - support for adding option flags to submit (0.0.15)
  - support for `is_launcher` parameter to indicate a launcher should be used instead (0.0.14)
  - support for streaming job output (0.0.13)
  - ensure logs end with one newline! (0.0.12)

--- a/clients/python/flux_restful_client/main/client.py
+++ b/clients/python/flux_restful_client/main/client.py
@@ -213,6 +213,7 @@ class FluxRestfulClient:
         cores_per_task (int): Number of cores per task (default to 1)
         gpus_per_task (int): Number of gpus per task (defaults to None)
         num_nodes (int): Number of nodes (defaults to None)
+        option_flags (dict): Option flags (as dict, defaults to {})
         exclusive (bool): is the job exclusive? (defaults to False)
         is_launcher (bool): the command should be submit to a launcher.
         This is currently supported for snakemake and nextflow.
@@ -225,6 +226,7 @@ class FluxRestfulClient:
             "num_tasks",
             "cores_per_task",
             "gpus_per_task",
+            "option_flags",
             "num_nodes",
             "exclusive",
             "is_launcher",
@@ -237,6 +239,7 @@ class FluxRestfulClient:
                 data[optional] = kwargs[optional]
 
         # Validate the data first.
+        print(data)
         jsonschema.validate(data, schema=schemas.job_submit_schema)
         result = self.do_request("jobs/submit", "POST", data=data)
         if result.status_code == 404:

--- a/clients/python/flux_restful_client/main/schemas.py
+++ b/clients/python/flux_restful_client/main/schemas.py
@@ -42,6 +42,10 @@ submit_properties = {
         "type": ["number", "null"],
         "description": "number of nodes for the job.",
     },
+    "option_flags": {
+        "type": "object",
+        "description": "option flags (dict) or key value pairs for flux.",
+    },
     "exclusive": {
         "type": ["boolean", "null"],
         "description": "ask for exclusive nodes for the job.",

--- a/clients/python/flux_restful_client/tests/test_api.py
+++ b/clients/python/flux_restful_client/tests/test_api.py
@@ -1,5 +1,7 @@
 import time
 
+import jsonschema
+import pytest
 from flux_restful_client.main import get_client
 
 
@@ -75,6 +77,22 @@ def test_job_output():
     lines = client.output(jobid)
     assert "Output" in lines
     assert "pancakes 🥞️🥞️🥞️\n" in lines["Output"]
+
+
+def test_option_flags():
+    """
+    Test adding valid and invalid option flags
+    """
+    client = get_client()
+
+    with pytest.raises(jsonschema.ValidationError):
+        client.submit("sleep 1", option_flags="invalid format")
+
+    # The server should reject a key with -o
+    result = client.submit("sleep 1", option_flags={"-ompi": "noodles"})
+    assert "Errors" in result
+    assert result["Errors"]
+    assert "keys without -o" in result["Errors"][0]
 
 
 def test_job_query():

--- a/clients/python/flux_restful_client/version.py
+++ b/clients/python/flux_restful_client/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.14"
+__version__ = "0.0.15"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "flux-restful-client"

--- a/docs/getting_started/developer-guide.md
+++ b/docs/getting_started/developer-guide.md
@@ -147,6 +147,30 @@ The following variables are available (with their defaults):
 |FLUX_USER| The username to require for Basic Auth (if `FLUX_REQUIRE_AUTH` is set) | unset |
 |FLUX_HAS_GPU | GPUs are available for the user to request | unset |
 |FLUX_NUMBER_NODES| The number of nodes available in the cluster | 1 |
+|FLUX_OPTION_FLAGS | Option flags to give to flux, in the same format you'd give on the command line | unset |
+
+### Flux Option Flags
+
+Option flags can be set server-wide or on the fly by a user in the interface
+(or restful API). An option set by a user will over-ride the server setting.
+An example setting a server-level option flags is below:
+
+```bash
+export FLUX_OPTION_FLAGS="-ompi=openmpi@5"
+```
+
+This would be translated to:
+
+```python
+fluxjob = flux.job.JobspecV1.from_command(command, **kwargs)
+fluxjob.setattr_shell_option("mpi", "openmpi@5")
+```
+
+And note that you can easily set more than one:
+
+```bash
+export FLUX_OPTION_FLAGS="-ompi=openmpi@5 -okey=value"
+```
 
 ## Code Linting
 

--- a/templates/jobs/submit.html
+++ b/templates/jobs/submit.html
@@ -58,6 +58,11 @@
                     <input type="number" min="1" max="{{num_nodes}}" name="num_nodes" class="form-control" id="num_nodes" aria-describedby="num_nodesHelp">
                     <div id="num_nodesHelp" class="form-text">Number of nodes to request for the job, defaults to 1 (optional).</div>
                 </div>
+                <div class="mb-3">
+                    <label for="workdir" class="form-label">Option Flags</label>
+                    <input class="form-control" {% if form.option_flags %}value="{{ form.option_flags }}"{% endif %} name="option_fags" id="option_flags" aria-describedby="optionFlagsHelp">
+                    <div id="optionFlagsHelp" class="form-text">One off option flags, space separated (e.g.,) -ompi=openmpi@5 (optional).</div>
+                </div>
                 <div class="mb-3 form-check">
                   <input type="checkbox" class="form-check-input" name="exclusive" {% if form.exclusive %}checked{% endif %} id="exclusive" aria-describedby="exclusiveHelp">
                   <label class="form-check-label" for="exclusive">Exclusive</label>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -116,6 +116,45 @@ def test_cancel_job():
     # TODO we don't have way to actually verify that cancel happened
 
 
+def test_submit_option_flags():
+    """
+    Test that option flags are parsed.
+    """
+    # Submit a job with invalid flags
+    response = client.post(
+        "/v1/jobs/submit",
+        json={"command": "sleep 1", "option_flags": "invalid"},
+        headers=headers,
+    )
+    assert response.status_code == 400
+    result = response.json()
+    errors = result.get("Errors")
+    assert errors
+    assert "is invalid" in errors[0]
+
+    # Another invalid pattern
+    response = client.post(
+        "/v1/jobs/submit",
+        json={"command": "sleep 1", "option_flags": {"-ompi": "nope"}},
+        headers=headers,
+    )
+    assert response.status_code == 400
+    result = response.json()
+    errors = result.get("Errors")
+    assert errors
+    assert "keys without -o" in errors[0]
+
+    # Valid
+    response = client.post(
+        "/v1/jobs/submit",
+        json={"command": "sleep 1", "option_flags": {"ompi": "openmpi@5"}},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert "id" in result
+
+
 def test_job_output():
     """
     Test endpoint to retrieve list of job output


### PR DESCRIPTION
The flags can be defined in the environment for a server level setting, or on the fly by a user request. The user request always over-rides the environment, and in this we assume the user knows what they are doing :)

The terminal will print out the flags added so we can sanity check:

![Screenshot from 2022-12-16 17-26-52](https://user-images.githubusercontent.com/814322/208215060-364ea490-6693-440d-9bdd-7c15ab1ca81c.png)

When tests pass here I'll test out this branch with my OSU benchmark container. if that works, we should be good to merge, and then I'll test with the operator. When that works I'll draft the release.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>